### PR TITLE
Add the WIP guide to the issue template

### DIFF
--- a/ISSUE_TEMPLATE
+++ b/ISSUE_TEMPLATE
@@ -1,3 +1,5 @@
+Make sure to check out our [guide to starting a breakout group](https://docs.google.com/document/d/1nYdhpguK7dl823u6G6EpN1GhGksHXVd8l_e1RB3FQF4/edit?usp=sharing)!
+
 ### About the group
 A high level overview of your breakout group. What problem are you trying to solve? Make this simple and jargon-free. Links are good too!
 


### PR DESCRIPTION
Adding a link to the work in progress guide to starting a breakout group! As discussed in the leadership team meeting this week, it sounded like we're open to putting something up there while we continue working on refining the broader guide. The guide still has a link at the top to the work in progress V2, which I think makes sense :). This goes along with https://github.com/chihacknight/chihacknight.org/pull/140